### PR TITLE
Fix POST /api/tours authorization

### DIFF
--- a/backend/src/main/java/com/sl_tourpal/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/sl_tourpal/backend/config/SecurityConfig.java
@@ -50,6 +50,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/auth/logout").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/auth/verify").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/destination/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/tours").hasAuthority("CREATE_TOUR")
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated())
                 .addFilter(authFilter)

--- a/backend/src/main/java/com/sl_tourpal/backend/controller/TourController.java
+++ b/backend/src/main/java/com/sl_tourpal/backend/controller/TourController.java
@@ -6,6 +6,7 @@ import com.sl_tourpal.backend.service.TourService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 @RestController
 @RequestMapping("/api/tours")
@@ -16,6 +17,7 @@ public class TourController {
     }
 
     @PostMapping
+    @PreAuthorize("hasAuthority('CREATE_TOUR')")
     public ResponseEntity<Tour> createNewTour(@Valid @RequestBody AddTourRequest req) {
         Tour created = tourService.createTour(req);
         return ResponseEntity.status(201).body(created);


### PR DESCRIPTION
## Summary
- restrict tour creation endpoint to `CREATE_TOUR` privilege
- add method level security check

## Testing
- `mvnw test` *(fails: repo.maven.apache.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685a302bde488320b72ee310bf04794e