### PR TITLE
Improve JWT authorization header parsing

### DIFF
--- a/backend/src/main/java/com/sl_tourpal/backend/security/JwtAuthorizationFilter.java
+++ b/backend/src/main/java/com/sl_tourpal/backend/security/JwtAuthorizationFilter.java
@@ -33,8 +33,10 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     String token = null;
     String username = null;
 
-    if (header != null && header.startsWith("Bearer ")) {
-      token = header.substring(7);
+    if (header != null) {
+      token = header.startsWith("Bearer ")
+              ? header.substring(7)
+              : header;
       try {
         username = jwtUtil.extractUsername(token);
       } catch (Exception e) {


### PR DESCRIPTION
## Summary
- handle authorization header whether or not it contains the `Bearer` prefix

## Testing
- `./mvnw -q test` *(fails: Failed to fetch apache-maven due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685adad2b8e88320a8df3760b554031c